### PR TITLE
Secure DNS download via token.

### DIFF
--- a/netmgt/export.py
+++ b/netmgt/export.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponse
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import PermissionDenied
 from django.views.decorators.http import condition
 from django.conf import settings
 from models import *
@@ -105,6 +106,8 @@ def etag_last_modified(request=None):
 
 
 def text(request):
+	if request.GET.get('token', False) != settings.NETMGT_DNS_TOKEN:
+		raise PermissionDenied
 	zones = generate_zones()
 	response = HttpResponse(content_type='text/plain')
 	response.write('\n\n'.join(zones.values()))
@@ -113,6 +116,8 @@ def text(request):
 
 @condition(etag_func=etag_last_modified, last_modified_func=total_last_modified)
 def export(request):
+	if request.GET.get('token', False) != settings.NETMGT_DNS_TOKEN:
+		raise PermissionDenied
 	zones = generate_zones()
 	response = HttpResponse(content_type='application/x-zip')
 	response['Content-Disposition'] = 'attachment; filename=zones.zip'

--- a/netmgt_web/settings.py
+++ b/netmgt_web/settings.py
@@ -77,3 +77,4 @@ NETMGT_SOA = {
 	'expiry':  '2w',
 	'minimum': '1h',
 }
+NETMGT_DNS_TOKEN = 'secure'


### PR DESCRIPTION
I've added a setting `NETMGT_DNS_TOKEN` which is required to download the DNS information from the server.
